### PR TITLE
Upgrade to ABP 9.1

### DIFF
--- a/src/QuestionsAnswers.Application/QuestionsAnswers.Application.csproj
+++ b/src/QuestionsAnswers.Application/QuestionsAnswers.Application.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\QuestionsAnswers.Core\QuestionsAnswers.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Abp.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Abp.AutoMapper" Version="9.0.0" />
+    <PackageReference Include="Abp.EntityFrameworkCore" Version="9.1.0" />
+    <PackageReference Include="Abp.AutoMapper" Version="9.1.0" />
   </ItemGroup>
 </Project>

--- a/src/QuestionsAnswers.Core/Identity/SecurityStampValidator.cs
+++ b/src/QuestionsAnswers.Core/Identity/SecurityStampValidator.cs
@@ -15,10 +15,9 @@ namespace QuestionsAnswers.Identity
         public SecurityStampValidator(
             IOptions<SecurityStampValidatorOptions> options,
             SignInManager signInManager,
-            ISystemClock systemClock,
             ILoggerFactory loggerFactory,
             IUnitOfWorkManager unitOfWorkManager)
-            : base(options, signInManager, systemClock, loggerFactory, unitOfWorkManager)
+            : base(options, signInManager, loggerFactory, unitOfWorkManager)
         {
         }
     }

--- a/src/QuestionsAnswers.Core/QuestionsAnswers.Core.csproj
+++ b/src/QuestionsAnswers.Core/QuestionsAnswers.Core.csproj
@@ -14,8 +14,8 @@
     <EmbeddedResource Include="Localization\SourceFiles\*.json" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Abp.AutoMapper" Version="9.0.0" />
-    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Abp.AutoMapper" Version="9.1.0" />
+    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="9.1.0" />
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />

--- a/src/QuestionsAnswers.EntityFrameworkCore/QuestionsAnswers.EntityFrameworkCore.csproj
+++ b/src/QuestionsAnswers.EntityFrameworkCore/QuestionsAnswers.EntityFrameworkCore.csproj
@@ -18,16 +18,16 @@
     <ProjectReference Include="..\QuestionsAnswers.Core\QuestionsAnswers.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Abp.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+    <PackageReference Include="Abp.EntityFrameworkCore" Version="9.1.0" />
+    <PackageReference Include="Abp.ZeroCore.EntityFrameworkCore" Version="9.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/QuestionsAnswers.Migrator/QuestionsAnswers.Migrator.csproj
+++ b/src/QuestionsAnswers.Migrator/QuestionsAnswers.Migrator.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Abp.Castle.Log4Net" Version="9.0.0" />
+    <PackageReference Include="Abp.Castle.Log4Net" Version="9.1.0" />
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="4.1.0" />
   </ItemGroup>
 

--- a/src/QuestionsAnswers.Web/QuestionsAnswers.Web.csproj
+++ b/src/QuestionsAnswers.Web/QuestionsAnswers.Web.csproj
@@ -46,9 +46,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.Web.Optimization" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.1" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="Castle.LoggingFacility.MsLogging" Version="3.1.0" />
@@ -56,8 +56,8 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
-    <PackageReference Include="Abp.AspNetCore" Version="9.0.0" />
-    <PackageReference Include="Abp.Castle.Log4Net" Version="9.0.0" />
+    <PackageReference Include="Abp.AspNetCore" Version="9.1.0" />
+    <PackageReference Include="Abp.Castle.Log4Net" Version="9.1.0" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0" />


### PR DESCRIPTION
Resolves [aspnetboilerplate/issues/6879](https://github.com/aspnetboilerplate/aspnetboilerplate/issues/6879)

ABP packages have been upgraded to version 9.1. The SecurityStampValidator class has been updated.